### PR TITLE
fog: overlay: Adapt statusbar dimens to Android 11

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,3 +1,6 @@
 soong_namespace {
-     imports: ["hardware/qcom-caf/bootctrl"],
+    imports: [
+        "hardware/qcom-caf/bootctrl",
+        "hardware/xiaomi",
+    ],
 }

--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -17,19 +17,16 @@
 -->
 <resources>
     <!-- the padding on the start of the statusbar -->
-    <dimen name="status_bar_padding_start">10dp</dimen>
+    <dimen name="status_bar_padding_start">8dp</dimen>
 
     <!-- the padding on the end of the statusbar -->
-    <dimen name="status_bar_padding_end">2dp</dimen>
+    <dimen name="status_bar_padding_end">4dp</dimen>
 
     <!-- rounded corner content padding -->
     <dimen name="rounded_corner_content_padding">18dp</dimen>
 
-    <!--  Total minimum padding to enforce to ensure that the dot can always show  -->
-    <dimen name="ongoing_appops_dot_min_padding">18dp</dimen>
-
     <!-- Margin on the left side of the carrier text on Keyguard -->
-    <dimen name="keyguard_carrier_text_margin">10dp</dimen>
+    <dimen name="keyguard_carrier_text_margin">8dp</dimen>
 
     <!-- Height of the status bar header bar when on Keyguard -->
     <dimen name="status_bar_header_height_keyguard">@*android:dimen/status_bar_height</dimen>


### PR DESCRIPTION
- Remove ongoing_appops_dot_min_padding since it's for Android 12+ 
- Set status_bar_padding_start to 8dp, set status_bar_padding_end to 4dp